### PR TITLE
Add unit testing for react to project

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -20,8 +20,9 @@ jobs:
 
     - name: Build
       run: |
-        npm install
+        npm ci
         npm run build
+        npm test
 
     - name: Upload build directory
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
- Changed ```npm install``` to ```npm ci```as this command is the designated command to safely install dependencies in a CI pipeline (see [here](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more infos.
- Added ```npm test```to automatically execute react tests 